### PR TITLE
Add a minimal Pathfinder Unity API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ path = "pathfinder/gpu"
 
 [dependencies.pathfinder_gl]
 path = "pathfinder/gl"
+
+[dependencies.pathfinder_simd]
+path = "pathfinder/simd"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod unity_interfaces;
 mod gl_util;
 mod render;
 mod logging;
+mod pathfinder_unity_api;
 
 use unity_interfaces::{
     IUnityGraphics,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate enum_primitive_derive;
 
 use std::env;
 use std::path::PathBuf;
+use std::sync::Mutex;
 use libc::c_int;
 
 mod unity_interfaces;
@@ -11,6 +12,8 @@ mod render;
 mod logging;
 mod pathfinder_unity_api;
 
+use pathfinder_canvas::CanvasRenderingContext2D;
+use pathfinder_unity_api::PFCanvasRef;
 use unity_interfaces::{
     IUnityGraphics,
     IUnityInterfaces,
@@ -25,6 +28,7 @@ use logging::log;
 struct PluginState {
     unity_interfaces: *const IUnityInterfaces,
     unity_renderer: Option<UnityGfxRenderer>,
+    canvas: Mutex<Option<Box<CanvasRenderingContext2D>>>,
     renderer: Option<Renderer>,
     errored: bool
 }
@@ -34,6 +38,7 @@ impl PluginState {
         let mut plugin = PluginState {
             unity_interfaces,
             unity_renderer: None,
+            canvas: Mutex::new(None),
             renderer: None,
             errored: false
         };
@@ -117,6 +122,11 @@ impl PluginState {
         }
     }
 
+    pub fn set_canvas(&mut self, canvas: Box<CanvasRenderingContext2D>) {
+        let mut locked_canvas = self.canvas.lock().unwrap();
+        *locked_canvas = Some(canvas);
+    }
+
     pub fn render(&mut self) {
         if self.errored {
             return;
@@ -126,7 +136,9 @@ impl PluginState {
                 self.try_to_init_renderer();
             }
             if let Some(renderer) = &mut self.renderer {
-                renderer.render();
+                if let Some(canvas) = self.canvas.lock().unwrap().take() {
+                    renderer.render(canvas);
+                }
             }
         } else {
             log(format!(
@@ -187,4 +199,9 @@ extern "stdcall" fn handle_render_event(_event_id: c_int) {
 #[no_mangle]
 pub extern "stdcall" fn get_render_event_func() -> UnityRenderingEvent {
     handle_render_event
+}
+
+#[no_mangle]
+pub extern "stdcall" fn queue_canvas_for_rendering(canvas: PFCanvasRef) {
+    get_plugin_state_mut().set_canvas(unsafe { Box::from_raw(canvas) });
 }

--- a/src/pathfinder_unity_api.rs
+++ b/src/pathfinder_unity_api.rs
@@ -1,0 +1,365 @@
+// This file is taken from revision 848eb0044353b735b9db2b1e1457b8e0930e2adf
+// of the Pathfinder Project, and modified to suit the needs of the Unity
+// plugin. Hopefully we will be able to merge changes upstream somehow so
+// that this fork of the original doesn't need to exist.
+
+// pathfinder/c/src/lib.rs
+//
+// Copyright © 2019 The Pathfinder Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! C bindings to Pathfinder.
+
+use gl;
+use pathfinder_canvas::{CanvasRenderingContext2D, Path2D};
+use pathfinder_geometry::basic::point::{Point2DF32, Point2DI32};
+use pathfinder_geometry::basic::rect::{RectF32, RectI32};
+use pathfinder_geometry::color::ColorF;
+use pathfinder_gl::{GLDevice, GLVersion};
+use pathfinder_gpu::resources::{FilesystemResourceLoader, ResourceLoader};
+use pathfinder_gpu::{ClearParams, Device};
+use pathfinder_renderer::concurrent::rayon::RayonExecutor;
+use pathfinder_renderer::concurrent::scene_proxy::SceneProxy;
+use pathfinder_renderer::gpu::renderer::{DestFramebuffer, Renderer};
+use pathfinder_renderer::options::RenderOptions;
+use pathfinder_renderer::scene::Scene;
+use pathfinder_simd::default::F32x4;
+use std::ffi::CString;
+use std::os::raw::{c_char, c_void};
+
+// Constants
+
+pub const PF_CLEAR_FLAGS_HAS_COLOR:   u8 = 0x1;
+pub const PF_CLEAR_FLAGS_HAS_DEPTH:   u8 = 0x2;
+pub const PF_CLEAR_FLAGS_HAS_STENCIL: u8 = 0x4;
+pub const PF_CLEAR_FLAGS_HAS_RECT:    u8 = 0x8;
+
+// Types
+
+// `canvas`
+pub type PFCanvasRef = *mut CanvasRenderingContext2D;
+pub type PFPathRef = *mut Path2D;
+
+// `geometry`
+#[repr(C)]
+pub struct PFPoint2DF {
+    pub x: f32,
+    pub y: f32,
+}
+#[repr(C)]
+pub struct PFPoint2DI {
+    pub x: i32,
+    pub y: i32,
+}
+#[repr(C)]
+pub struct PFRectF {
+    pub origin: PFPoint2DF,
+    pub lower_right: PFPoint2DF,
+}
+#[repr(C)]
+pub struct PFRectI {
+    pub origin: PFPoint2DI,
+    pub lower_right: PFPoint2DI,
+}
+#[repr(C)]
+pub struct PFColorF {
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+    pub a: f32,
+}
+
+// `gl`
+pub type PFGLDeviceRef = *mut GLDevice;
+pub type PFGLVersion = GLVersion;
+pub type PFGLFunctionLoader = extern "stdcall" fn(name: *const c_char, userdata: *mut c_void)
+                                            -> *const c_void;
+// `gpu`
+pub type PFGLDestFramebufferRef = *mut DestFramebuffer<GLDevice>;
+pub type PFGLRendererRef = *mut Renderer<GLDevice>;
+// FIXME(pcwalton): Double-boxing is unfortunate. Remove this when `std::raw::TraitObject` is
+// stable?
+pub type PFResourceLoaderRef = *mut Box<dyn ResourceLoader>;
+#[repr(C)]
+pub struct PFClearParams {
+    pub color: PFColorF,
+    pub depth: f32,
+    pub stencil: u8,
+    pub rect: PFRectI,
+    pub flags: PFClearFlags,
+}
+pub type PFClearFlags = u8;
+
+// `renderer`
+pub type PFSceneRef = *mut Scene;
+pub type PFSceneProxyRef = *mut SceneProxy;
+// TODO(pcwalton)
+#[repr(C)]
+pub struct PFRenderOptions {
+    pub placeholder: u32,
+}
+
+// `canvas`
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasCreate(size: *const PFPoint2DF) -> PFCanvasRef {
+    Box::into_raw(Box::new(CanvasRenderingContext2D::new((*size).to_rust())))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasDestroy(canvas: PFCanvasRef) {
+    drop(Box::from_raw(canvas))
+}
+
+/// Consumes the canvas.
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasCreateScene(canvas: PFCanvasRef) -> PFSceneRef {
+    Box::into_raw(Box::new(Box::from_raw(canvas).into_scene()))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasFillRect(canvas: PFCanvasRef, rect: *const PFRectF) {
+    (*canvas).fill_rect((*rect).to_rust())
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasStrokeRect(canvas: PFCanvasRef, rect: *const PFRectF) {
+    (*canvas).stroke_rect((*rect).to_rust())
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasSetLineWidth(canvas: PFCanvasRef, new_line_width: f32) {
+    (*canvas).set_line_width(new_line_width)
+}
+
+/// Consumes the path.
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasFillPath(canvas: PFCanvasRef, path: PFPathRef) {
+    (*canvas).fill_path(*Box::from_raw(path))
+}
+
+/// Consumes the path.
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasStrokePath(canvas: PFCanvasRef, path: PFPathRef) {
+    (*canvas).stroke_path(*Box::from_raw(path))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFPathCreate() -> PFPathRef {
+    Box::into_raw(Box::new(Path2D::new()))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFPathDestroy(path: PFPathRef) {
+    drop(Box::from_raw(path))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFPathClone(path: PFPathRef) -> PFPathRef {
+    Box::into_raw(Box::new((*path).clone()))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFPathMoveTo(path: PFPathRef, to: *const PFPoint2DF) {
+    (*path).move_to((*to).to_rust())
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFPathLineTo(path: PFPathRef, to: *const PFPoint2DF) {
+    (*path).line_to((*to).to_rust())
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFPathQuadraticCurveTo(path: PFPathRef,
+                                                ctrl: *const PFPoint2DF,
+                                                to: *const PFPoint2DF) {
+    (*path).quadratic_curve_to((*ctrl).to_rust(), (*to).to_rust())
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFPathBezierCurveTo(path: PFPathRef,
+                                             ctrl0: *const PFPoint2DF,
+                                             ctrl1: *const PFPoint2DF,
+                                             to: *const PFPoint2DF) {
+    (*path).bezier_curve_to((*ctrl0).to_rust(), (*ctrl1).to_rust(), (*to).to_rust())
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFPathClosePath(path: PFPathRef) {
+    (*path).close_path()
+}
+
+// `gl`
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFFilesystemResourceLoaderLocate() -> PFResourceLoaderRef {
+    let loader = Box::new(FilesystemResourceLoader::locate());
+    Box::into_raw(Box::new(loader as Box<dyn ResourceLoader>))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFGLLoadWith(loader: PFGLFunctionLoader, userdata: *mut c_void) {
+    gl::load_with(|name| {
+        let name = CString::new(name).unwrap();
+        loader(name.as_ptr(), userdata)
+    });
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFGLDeviceCreate(version: PFGLVersion, default_framebuffer: u32)
+                                          -> PFGLDeviceRef {
+    Box::into_raw(Box::new(GLDevice::new(version, default_framebuffer)))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFGLDeviceDestroy(device: PFGLDeviceRef) {
+    drop(Box::from_raw(device))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFGLDeviceClear(device: PFGLDeviceRef, params: *const PFClearParams) {
+    (*device).clear(&(*params).to_rust())
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFResourceLoaderDestroy(loader: PFResourceLoaderRef) {
+    drop(Box::from_raw(loader))
+}
+
+// `gpu`
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFGLDestFramebufferCreateFullWindow(window_size: *const PFPoint2DI)
+                                                             -> PFGLDestFramebufferRef {
+    Box::into_raw(Box::new(DestFramebuffer::full_window((*window_size).to_rust())))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFGLDestFramebufferDestroy(dest_framebuffer: PFGLDestFramebufferRef) {
+    drop(Box::from_raw(dest_framebuffer))
+}
+
+/// Takes ownership of `device` and `dest_framebuffer`, but not `resources`.
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFGLRendererCreate(device: PFGLDeviceRef,
+                                            resources: PFResourceLoaderRef,
+                                            dest_framebuffer: PFGLDestFramebufferRef)
+                                            -> PFGLRendererRef {
+    Box::into_raw(Box::new(Renderer::new(*Box::from_raw(device),
+                                         &**resources,
+                                         *Box::from_raw(dest_framebuffer))))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFGLRendererDestroy(renderer: PFGLRendererRef) {
+    drop(Box::from_raw(renderer))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFGLRendererGetDevice(renderer: PFGLRendererRef) -> PFGLDeviceRef {
+    &mut (*renderer).device
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFSceneProxyBuildAndRenderGL(scene_proxy: PFSceneProxyRef,
+                                                      renderer: PFGLRendererRef,
+                                                      options: *const PFRenderOptions) {
+    (*scene_proxy).build_and_render(&mut *renderer, (*options).to_rust())
+}
+
+// `renderer`
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFSceneDestroy(scene: PFSceneRef) {
+    drop(Box::from_raw(scene))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFSceneProxyCreateFromSceneAndRayonExecutor(scene: PFSceneRef)
+                                                                     -> PFSceneProxyRef {
+    Box::into_raw(Box::new(SceneProxy::from_scene(*Box::from_raw(scene), RayonExecutor)))
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFSceneProxyDestroy(scene_proxy: PFSceneProxyRef) {
+    drop(Box::from_raw(scene_proxy))
+}
+
+// Helpers for `geometry`
+
+impl PFColorF {
+    #[inline]
+    pub fn to_rust(&self) -> ColorF {
+        ColorF(F32x4::new(self.r, self.g, self.b, self.a))
+    }
+}
+
+impl PFRectF {
+    #[inline]
+    pub fn to_rust(&self) -> RectF32 {
+        RectF32::from_points(self.origin.to_rust(), self.lower_right.to_rust())
+    }
+}
+
+impl PFRectI {
+    #[inline]
+    pub fn to_rust(&self) -> RectI32 {
+        RectI32::from_points(self.origin.to_rust(), self.lower_right.to_rust())
+    }
+}
+
+impl PFPoint2DF {
+    #[inline]
+    pub fn to_rust(&self) -> Point2DF32 {
+        Point2DF32::new(self.x, self.y)
+    }
+}
+
+impl PFPoint2DI {
+    #[inline]
+    pub fn to_rust(&self) -> Point2DI32 {
+        Point2DI32::new(self.x, self.y)
+    }
+}
+
+// Helpers for `gpu`
+
+impl PFClearParams {
+    pub fn to_rust(&self) -> ClearParams {
+        ClearParams {
+            color: if (self.flags & PF_CLEAR_FLAGS_HAS_COLOR) != 0 {
+                Some(self.color.to_rust())
+            } else {
+                None
+            },
+            rect: if (self.flags & PF_CLEAR_FLAGS_HAS_RECT) != 0 {
+                Some(self.rect.to_rust())
+            } else {
+                None
+            },
+            depth: if (self.flags & PF_CLEAR_FLAGS_HAS_DEPTH) != 0 {
+                Some(self.depth)
+            } else {
+                None
+            },
+            stencil: if (self.flags & PF_CLEAR_FLAGS_HAS_STENCIL) != 0 {
+                Some(self.stencil)
+            } else {
+                None
+            },
+        }
+    }
+}
+
+// Helpers for `renderer`
+
+impl PFRenderOptions {
+    pub fn to_rust(&self) -> RenderOptions {
+        RenderOptions::default()
+    }
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
-use pathfinder_canvas::{CanvasRenderingContext2D, Path2D};
-use pathfinder_geometry::basic::point::{Point2DF32, Point2DI32};
-use pathfinder_geometry::basic::rect::RectF32;
+use pathfinder_canvas::{CanvasRenderingContext2D};
+use pathfinder_geometry::basic::point::{Point2DI32};
 use pathfinder_gpu::resources::FilesystemResourceLoader;
 use pathfinder_gl::{GLDevice, GLVersion};
 use pathfinder_renderer::gpu::renderer::DestFramebuffer;
@@ -68,29 +67,9 @@ impl Renderer {
         }
     }
 
-    pub fn render(&mut self) {
+    pub fn render(&mut self, canvas: Box<CanvasRenderingContext2D>) {
         self.sync_gfx_state();
         let renderer = &mut self.renderer;
-
-        // Make a canvas. We're going to draw a house.
-        let mut canvas = CanvasRenderingContext2D::new(self.window_size.to_f32());
-
-        // Set line width.
-        canvas.set_line_width(10.0);
-
-        // Draw walls.
-        canvas.stroke_rect(RectF32::new(Point2DF32::new(75.0, 140.0), Point2DF32::new(150.0, 110.0)));
-
-        // Draw door.
-        canvas.fill_rect(RectF32::new(Point2DF32::new(130.0, 190.0), Point2DF32::new(40.0, 60.0)));
-
-        // Draw roof.
-        let mut path = Path2D::new();
-        path.move_to(Point2DF32::new(50.0, 140.0));
-        path.line_to(Point2DF32::new(150.0, 60.0));
-        path.line_to(Point2DF32::new(250.0, 140.0));
-        path.close_path();
-        canvas.stroke_path(path);
 
         // Render the canvas to screen.
         let scene = SceneProxy::from_scene(canvas.into_scene(), RayonExecutor);

--- a/src/render.rs
+++ b/src/render.rs
@@ -9,6 +9,7 @@ use pathfinder_renderer::concurrent::rayon::RayonExecutor;
 use pathfinder_renderer::concurrent::scene_proxy::SceneProxy;
 use pathfinder_renderer::options::RenderOptions;
 use pathfinder_renderer::gpu::renderer::Renderer as PathfinderRenderer;
+use gl::types::GLuint;
 
 use crate::logging::log;
 use crate::gl_util::{get_viewport_size, get_draw_framebuffer_binding};
@@ -20,11 +21,11 @@ fn get_current_window_size() -> Point2DI32 {
 
 fn build_renderer(
     window_size: Point2DI32,
+    framebuffer: GLuint,
     loader: &FilesystemResourceLoader
 ) -> PathfinderRenderer<GLDevice> {
-    let fbo_id = get_draw_framebuffer_binding();
     pathfinder_renderer::gpu::renderer::Renderer::new(
-        GLDevice::new(GLVersion::GL3, fbo_id),
+        GLDevice::new(GLVersion::GL3, framebuffer),
         loader,
         DestFramebuffer::full_window(window_size)
     )
@@ -32,41 +33,43 @@ fn build_renderer(
 
 pub struct Renderer {
     renderer: PathfinderRenderer<GLDevice>,
-    window_size: Point2DI32
+    window_size: Point2DI32,
+    framebuffer: GLuint
 }
 
 impl Renderer {
     pub fn new(resources_dir: PathBuf) -> Self {
         let window_size = get_current_window_size();
+        let framebuffer = get_draw_framebuffer_binding();
         let loader = FilesystemResourceLoader { directory: resources_dir };
-        let renderer = build_renderer(window_size, &loader);
+        let renderer = build_renderer(window_size, framebuffer, &loader);
 
-        Renderer { renderer, window_size }
+        Renderer { renderer, window_size, framebuffer }
     }
 
-    fn check_window_size(&mut self) {
+    // If Unity's window size/framebuffer changes, make sure our draw
+    // calls adapt.
+    fn sync_gfx_state(&mut self) {
+        let framebuffer = get_draw_framebuffer_binding();
         let window_size = get_current_window_size();
-        if window_size != self.window_size {
-            let fb = get_draw_framebuffer_binding();
+        if window_size != self.window_size || framebuffer != self.framebuffer {
             log(format!(
-                "Window size changed from {:?} to {:?} w/ fb {}.",
+                "Window size/framebuffer changed from {:?}/{} to {:?}/{}.",
                 self.window_size,
+                self.framebuffer,
                 window_size,
-                fb
+                framebuffer
             ));
             self.window_size = window_size;
-
-            // When Unity changes its window size, it often also changes the
-            // current draw framebuffer, so let's make sure that change is reflected.
-            self.renderer.device.set_default_framebuffer(get_draw_framebuffer_binding());
-
+            self.framebuffer = framebuffer;
+            self.renderer.device.set_default_framebuffer(framebuffer);
             self.renderer.replace_dest_framebuffer(DestFramebuffer::full_window(window_size));
             self.renderer.set_main_framebuffer_size(window_size);
         }
     }
 
     pub fn render(&mut self) {
-        self.check_window_size();
+        self.sync_gfx_state();
         let renderer = &mut self.renderer;
 
         // Make a canvas. We're going to draw a house.

--- a/unity-project/Assets/PathfinderCameraScript.cs
+++ b/unity-project/Assets/PathfinderCameraScript.cs
@@ -4,6 +4,53 @@ using UnityEngine;
 using System;
 using System.Runtime.InteropServices;
 
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+struct PFPoint2DF {
+    public float x;
+    public float y;
+
+    public PFPoint2DF(float x, float y) {
+        this.x = x;
+        this.y = y;
+    }
+}
+
+class PFPath {
+    private IntPtr handle;
+
+    [DllImport("GfxPluginPathfinder")]
+    private static extern IntPtr PFPathCreate();
+
+    [DllImport("GfxPluginPathfinder")]
+    private static extern void PFPathDestroy(IntPtr handle);
+
+    [DllImport("GfxPluginPathfinder")]
+    private static extern void PFPathMoveTo(IntPtr handle, ref PFPoint2DF to);
+
+    public PFPath() {
+        handle = PFPathCreate();
+    }
+
+    private void ensureNotConsumed() {
+        if (handle == IntPtr.Zero) {
+            throw new Exception("Path is already consumed!");
+        }
+    }
+
+    public void MoveTo(Vector2 to) {
+        ensureNotConsumed();
+        var point = new PFPoint2DF(to.x, to.y);
+        PFPathMoveTo(handle, ref point);
+    }
+
+    ~PFPath() {
+        if (handle != IntPtr.Zero) {
+            PFPathDestroy(handle);
+        }
+    }
+}
+
 public class PathfinderCameraScript : MonoBehaviour
 {
     [DllImport("GfxPluginPathfinder")]
@@ -12,6 +59,9 @@ public class PathfinderCameraScript : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        // TODO: This is temporary code, remove it.
+        var path = new PFPath();
+        path.MoveTo(new Vector2(5.0f, 10.0f));
     }
 
     public void OnPostRender() {

--- a/unity-project/Assets/PathfinderCameraScript.cs
+++ b/unity-project/Assets/PathfinderCameraScript.cs
@@ -29,7 +29,13 @@ class PFPath {
     private static extern IntPtr PFPathClone(IntPtr handle);
 
     [DllImport("GfxPluginPathfinder")]
+    private static extern void PFPathClosePath(IntPtr handle);
+
+    [DllImport("GfxPluginPathfinder")]
     private static extern void PFPathMoveTo(IntPtr handle, ref PFPoint2DF to);
+
+    [DllImport("GfxPluginPathfinder")]
+    private static extern void PFPathLineTo(IntPtr handle, ref PFPoint2DF to);
 
     public PFPath(PFPath targetToClone = null) {
         if (targetToClone != null) {
@@ -44,8 +50,17 @@ class PFPath {
         PFPathMoveTo(handle, ref point);
     }
 
+    public void LineTo(Vector2 to) {
+        var point = new PFPoint2DF(to.x, to.y);
+        PFPathLineTo(handle, ref point);
+    }
+
     public PFPath Clone() {
         return new PFPath(this);
+    }
+
+    public void ClosePath() {
+        PFPathClosePath(handle);
     }
 
     ~PFPath() {
@@ -61,9 +76,14 @@ public class PathfinderCameraScript : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        // TODO: This is temporary code, remove it.
+        // Draw roof.
         var path = new PFPath();
-        path.MoveTo(new Vector2(5.0f, 10.0f));
+        path.MoveTo(new Vector2(50.0f, 140.0f));
+        path.LineTo(new Vector2(150.0f, 60.0f));
+        path.LineTo(new Vector2(250.0f, 140.0f));
+        path.ClosePath();
+
+        // This is temporary code just to make sure calls don't crash.
         path.Clone();
     }
 

--- a/unity-project/Assets/PathfinderCameraScript.cs
+++ b/unity-project/Assets/PathfinderCameraScript.cs
@@ -26,28 +26,30 @@ class PFPath {
     private static extern void PFPathDestroy(IntPtr handle);
 
     [DllImport("GfxPluginPathfinder")]
+    private static extern IntPtr PFPathClone(IntPtr handle);
+
+    [DllImport("GfxPluginPathfinder")]
     private static extern void PFPathMoveTo(IntPtr handle, ref PFPoint2DF to);
 
-    public PFPath() {
-        handle = PFPathCreate();
-    }
-
-    private void ensureNotConsumed() {
-        if (handle == IntPtr.Zero) {
-            throw new Exception("Path is already consumed!");
+    public PFPath(PFPath targetToClone = null) {
+        if (targetToClone != null) {
+            handle = PFPathClone(targetToClone.handle);
+        } else {
+            handle = PFPathCreate();
         }
     }
 
     public void MoveTo(Vector2 to) {
-        ensureNotConsumed();
         var point = new PFPoint2DF(to.x, to.y);
         PFPathMoveTo(handle, ref point);
     }
 
+    public PFPath Clone() {
+        return new PFPath(this);
+    }
+
     ~PFPath() {
-        if (handle != IntPtr.Zero) {
-            PFPathDestroy(handle);
-        }
+        PFPathDestroy(handle);
     }
 }
 
@@ -62,6 +64,7 @@ public class PathfinderCameraScript : MonoBehaviour
         // TODO: This is temporary code, remove it.
         var path = new PFPath();
         path.MoveTo(new Vector2(5.0f, 10.0f));
+        path.Clone();
     }
 
     public void OnPostRender() {

--- a/unity-project/Assets/PathfinderCameraScript.cs
+++ b/unity-project/Assets/PathfinderCameraScript.cs
@@ -170,6 +170,7 @@ public class PathfinderCameraScript : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        // Make a canvas. We're going to draw a house.
         var canvas = new PFCanvas(new Vector2Int(300, 300));
 
         canvas.SetLineWidth(10.0f);


### PR DESCRIPTION
This attempts to port the Pathfinder C API to Unity/C# so that we can move the house drawing into C#, rather than being hard-coded into the plugin.

## Notes

* This PR (specifically, e4eeade) also changes rendering so it always checks to see if the current framebuffer ID has changed, and updates the Pathfinder renderer to target it if so.  This appears to fix the `OPENGL NATIVE PLUG-IN ERROR` in the Unity status bar/console log.

* It seems like [`Vector2`](https://docs.unity3d.com/ScriptReference/Vector2.html) is the type most familiar to Unity folks, so I'm having all the canvas/path wrappers take it instead of forcing clients to use Pathfinder's types.  The same goes for Unity's `Rect` type.

* ~~Because some operations actually consume the parameters to them (e.g. `PFCanvasFillPath` consumes the `PFPath` passed to it), and since C# has no concept for this, we need to add some manual checks to object methods to see if they've been consumed yet or not, and throw an exception if so.  This isn't ideal but I'm not sure what else to do.~~ This is no longer a problem; as @pcwalton suggested in https://github.com/servo/pathfinder/issues/147#issuecomment-497128874, we're just cloning the paths internally now.

* Unlike paths, canvas rendering contexts can't be cloned, so once they're handed-off for rendering, using them will raise an exception.

* Particularly because we need to export the API as `extern "stdcall"` on Windows rather than `extern "C"`, I've had to make a copy of `pathfinder/c/src/lib.rs` from the Pathfinder repository and modify it in this project, rather than reusing it from Pathfinder. Hopefully we can find a way to avoid doing that.

## To do

- [x] Port at least all the methods required to draw the house.
- [x] Figure out how we want the canvas to be handed off to Unity's graphics pipeline for drawing.
