### PR TITLE
Add preliminary support for render textures

### DIFF
--- a/src/gl_util.rs
+++ b/src/gl_util.rs
@@ -4,10 +4,11 @@ use winapi::um::wingdi::{wglGetProcAddress, wglGetCurrentContext};
 use winapi::um::libloaderapi::{LoadLibraryA, GetProcAddress};
 use winapi::shared::windef::HGLRC;
 use winapi::shared::ntdef::NULL;
-use winapi::um::processthreadsapi::GetCurrentThreadId;
 use gl::types::*;
 
 const OPENGL32_DLL: &'static [u8] = b"opengl32.dll\0";
+
+pub type Context = HGLRC;
 
 pub struct ContextWatcher {
     current_context: HGLRC
@@ -19,17 +20,13 @@ impl ContextWatcher {
         ContextWatcher { current_context: get_current_context() }
     }
 
-    pub fn changed(&mut self) -> bool {
+    pub fn check(&mut self) -> Context {
         let ctx = get_current_context();
         if ctx != self.current_context {
-            info!("OpenGL context changed from {:?} to {:?} on thread {}.",
-                  self.current_context, ctx, unsafe { GetCurrentThreadId() });
             self.current_context = ctx;
             init();
-            true
-        } else {
-            false
         }
+        self.current_context
     }
 }
 

--- a/src/gl_util.rs
+++ b/src/gl_util.rs
@@ -4,6 +4,7 @@ use winapi::um::wingdi::{wglGetProcAddress, wglGetCurrentContext};
 use winapi::um::libloaderapi::{LoadLibraryA, GetProcAddress};
 use winapi::shared::windef::HGLRC;
 use winapi::shared::ntdef::NULL;
+use winapi::um::processthreadsapi::GetCurrentThreadId;
 use gl::types::*;
 
 const OPENGL32_DLL: &'static [u8] = b"opengl32.dll\0";
@@ -21,7 +22,8 @@ impl ContextWatcher {
     pub fn changed(&mut self) -> bool {
         let ctx = get_current_context();
         if ctx != self.current_context {
-            info!("OpenGL context changed from {:?} to {:?}.", self.current_context, ctx);
+            info!("OpenGL context changed from {:?} to {:?} on thread {}.",
+                  self.current_context, ctx, unsafe { GetCurrentThreadId() });
             self.current_context = ctx;
             init();
             true

--- a/src/gl_util.rs
+++ b/src/gl_util.rs
@@ -14,6 +14,7 @@ pub struct ContextWatcher {
 
 impl ContextWatcher {
     pub fn new() -> Self {
+        init();
         ContextWatcher { current_context: get_current_context() }
     }
 
@@ -51,7 +52,7 @@ fn get_proc_address(name: &str) -> *const c_void {
     return ptr;
 }
 
-pub fn init() {
+fn init() {
     gl::load_with(get_proc_address);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,32 @@ enum PluginCommand {
 }
 
 struct PluginState {
+    // A pointer to Unity's plugin API that it gives us when our plugin
+    // is first loaded.
     unity_interfaces: *const IUnityInterfaces,
+
+    // The graphics backend that Unity is using.
     unity_renderer: Option<UnityGfxRenderer>,
+
+    // This is where we put Canvases that are ready to be rendered.
     canvases: Mutex<HashMap<i32, Box<CanvasRenderingContext2D>>>,
-    renderers: HashMap<gl_util::Context, Renderer>,
-    resources_dir: PathBuf,
+
+    // Unity sometimes switches between different GL contexts, so we need to
+    // check when the current context has changed and adapt accordingly.
     gl_context_watcher: Option<gl_util::ContextWatcher>,
+
+    // We use a separate renderer for each GL context that Unity uses. Ideally
+    // we'd have some separation between the kinds of resources that are shared
+    // between contexts (programs, shaders, etc) and those that aren't
+    // (framebuffers, vertex arrays, etc) so that we'd be able to manage resources
+    // more efficiently, but Pathfinder doesn't support such granularity right now.
+    renderers: HashMap<gl_util::Context, Renderer>,
+
+    // The directory where Pathfinder's resources (shaders, textures, etc) are.
+    resources_dir: PathBuf,
+
+    // Whether our plugin has had any errors or not. If it has, most calls to
+    // the plugin will be no-ops.
     errored: bool
 }
 
@@ -135,6 +155,13 @@ impl PluginState {
         let ctx = context_watcher.check();
         match cmd {
             PluginCommand::Shutdown => {
+                // This will only release the plugin's resources for the current
+                // GL context at the time that it's called, which isn't ideal. The
+                // alternative is to try to switch to the other GL contexts that
+                // our other renderers exist in, shut them down, and then switch
+                // back, but this feels dangerous (although it does seem to work; see
+                // https://github.com/toolness/pathfinder-unity-fun/pull/6 for a
+                // proof-of-concept).
                 let renderer = self.renderers.remove(&ctx);
                 if renderer.is_some() {
                     info!("Shutting down renderer for GL context {:?}!", ctx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,14 @@ impl PluginState {
             let context_watcher = self.gl_context_watcher.as_mut()
               .expect("GL context watcher should exist!");
             let ctx = context_watcher.check();
+            if canvas_id == 0 {
+                let renderer = self.renderers.remove(&ctx);
+                if renderer.is_some() {
+                    info!("Shutting down renderer for GL context {:?}.", ctx);
+                    drop(renderer);
+                }
+                return;
+            }
             let resources_dir = &self.resources_dir;
             let renderer = self.renderers.entry(ctx)
               .or_insert_with(|| {

--- a/src/render.rs
+++ b/src/render.rs
@@ -10,10 +10,10 @@ use pathfinder_renderer::options::BuildOptions;
 use pathfinder_renderer::gpu::renderer::Renderer as PathfinderRenderer;
 use gl::types::GLuint;
 
-use crate::gl_util::{get_viewport_size, get_draw_framebuffer_binding};
+use crate::gl_util;
 
 fn get_current_window_size() -> Vector2I {
-    let (_, _, width, height) = get_viewport_size();
+    let (_, _, width, height) = gl_util::get_viewport_size();
     Vector2I::new(width, height)
 }
 
@@ -22,46 +22,60 @@ fn build_renderer(
     framebuffer: GLuint,
     loader: &FilesystemResourceLoader
 ) -> PathfinderRenderer<GLDevice> {
-    pathfinder_renderer::gpu::renderer::Renderer::new(
+    info!("Creating a rendererer for framebuffer {}/{:?}.", framebuffer, window_size);
+    let renderer = pathfinder_renderer::gpu::renderer::Renderer::new(
         GLDevice::new(GLVersion::GL3, framebuffer),
         loader,
         DestFramebuffer::full_window(window_size),
         RendererOptions::default()
-    )
+    );
+
+    // During construction, Pathfinder currently binds its mask framebuffer
+    // as the current draw framebuffer and doesn't unbind it, so we'll do that
+    // ourselves.
+    gl_util::set_draw_framebuffer_binding(framebuffer);
+
+    renderer
 }
 
 pub struct Renderer {
     renderer: PathfinderRenderer<GLDevice>,
     window_size: Vector2I,
+    loader: FilesystemResourceLoader,
     framebuffer: GLuint
 }
 
 impl Renderer {
-    pub fn new(resources_dir: PathBuf) -> Self {
+    pub fn new(resources_dir: &PathBuf) -> Self {
         let window_size = get_current_window_size();
-        let framebuffer = get_draw_framebuffer_binding();
-        let loader = FilesystemResourceLoader { directory: resources_dir };
+        let framebuffer = gl_util::get_draw_framebuffer_binding();
+        let loader = FilesystemResourceLoader { directory: resources_dir.clone() };
         let renderer = build_renderer(window_size, framebuffer, &loader);
 
-        Renderer { renderer, window_size, framebuffer }
+        Renderer { renderer, window_size, framebuffer, loader }
     }
 
     // If Unity's window size/framebuffer changes, make sure our draw
     // calls adapt.
     fn sync_gfx_state(&mut self) {
-        let framebuffer = get_draw_framebuffer_binding();
+        let framebuffer = gl_util::get_draw_framebuffer_binding();
         let window_size = get_current_window_size();
-        if window_size != self.window_size || framebuffer != self.framebuffer {
+        if framebuffer != self.framebuffer {
             info!(
-                "Window size/framebuffer changed from {:?}/{} to {:?}/{}.",
-                self.window_size,
+                "Framebuffer changed from {} to {}.",
                 self.framebuffer,
-                window_size,
                 framebuffer
             );
-            self.window_size = window_size;
             self.framebuffer = framebuffer;
-            self.renderer.device.set_default_framebuffer(framebuffer);
+            self.window_size = window_size;
+            self.renderer = build_renderer(window_size, framebuffer, &self.loader);
+        } else if window_size != self.window_size {
+            info!(
+                "Window size changed from {:?} to {:?}.",
+                self.window_size,
+                window_size,
+            );
+            self.window_size = window_size;
             self.renderer.replace_dest_framebuffer(DestFramebuffer::full_window(window_size));
             self.renderer.set_main_framebuffer_size(window_size);
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -22,7 +22,6 @@ fn build_renderer(
     framebuffer: GLuint,
     loader: &FilesystemResourceLoader
 ) -> PathfinderRenderer<GLDevice> {
-    info!("Creating a rendererer for framebuffer {}/{:?}.", framebuffer, window_size);
     let renderer = pathfinder_renderer::gpu::renderer::Renderer::new(
         GLDevice::new(GLVersion::GL3, framebuffer),
         loader,
@@ -41,7 +40,6 @@ fn build_renderer(
 pub struct Renderer {
     renderer: PathfinderRenderer<GLDevice>,
     window_size: Vector2I,
-    loader: FilesystemResourceLoader,
     framebuffer: GLuint
 }
 
@@ -52,7 +50,7 @@ impl Renderer {
         let loader = FilesystemResourceLoader { directory: resources_dir.clone() };
         let renderer = build_renderer(window_size, framebuffer, &loader);
 
-        Renderer { renderer, window_size, framebuffer, loader }
+        Renderer { renderer, window_size, framebuffer }
     }
 
     // If Unity's window size/framebuffer changes, make sure our draw

--- a/unity-project/Assets/GlobalState.cs
+++ b/unity-project/Assets/GlobalState.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GlobalState : MonoBehaviour
+{
+    public static readonly string pathfinderToggleKey = "a";
+    private PFCanvasFontContext fontContext;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        fontContext = new PFCanvasFontContext();
+    }
+
+    public bool IsPathfinderEnabled() {
+        if (fontContext == null) {
+            PFPlugin.ReleaseResources();
+        }
+        return fontContext != null;
+    }
+
+    public PFCanvasFontContext GetFontContext() {
+        return fontContext;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (Input.GetKeyUp(pathfinderToggleKey)) {
+            if (fontContext != null) {
+                fontContext = null;
+            } else {
+                fontContext = new PFCanvasFontContext();
+            }
+        }
+        if (Input.GetKey("escape")) {
+            Application.Quit();
+        }
+    }
+}

--- a/unity-project/Assets/GlobalState.cs
+++ b/unity-project/Assets/GlobalState.cs
@@ -15,6 +15,10 @@ public class GlobalState : MonoBehaviour
 
     public bool IsPathfinderEnabled() {
         if (fontContext == null) {
+            // This will only release the plugin's resources for the current
+            // GL context at the time that it's called, so we'll intentionally
+            // call it frequently in hopes that it will eventually release
+            // the resources from all GL contexts that Unity uses.
             PFPlugin.ReleaseResources();
         }
         return fontContext != null;

--- a/unity-project/Assets/GlobalState.cs.meta
+++ b/unity-project/Assets/GlobalState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0fa03d726a130845a85815341ba02ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-project/Assets/Pathfinder/PFCanvas.cs
+++ b/unity-project/Assets/Pathfinder/PFCanvas.cs
@@ -10,6 +10,8 @@ public enum PFLineJoin : byte {
 public class PFCanvas {
     private IntPtr handle;
 
+    private static int nextCanvasId = 1;
+
     public PFCanvas(PFCanvasFontContext fontContext, Vector2 size) {
         var pfSize = PFUnityConv.PFVector2F(size);
         handle = PF.PFCanvasCreate(fontContext.PrepareToConsume(), ref pfSize);
@@ -76,7 +78,8 @@ public class PFCanvas {
         PF.PFCanvasFillPath(handle, pathHandleToConsume);
     }
 
-    public void QueueForRendering(Int32 id) {
+    public void QueueForRendering() {
+        var id = nextCanvasId++;
         PFPluginExports.queue_canvas_for_rendering(handle, id);
         handle = IntPtr.Zero;
         GL.IssuePluginEvent(PFPluginExports.get_render_canvas_func(), id);

--- a/unity-project/Assets/Pathfinder/PFPlugin.cs
+++ b/unity-project/Assets/Pathfinder/PFPlugin.cs
@@ -2,6 +2,6 @@ using UnityEngine;
 
 public class PFPlugin {
     public static void ReleaseResources() {
-        GL.IssuePluginEvent(PFPluginExports.get_render_canvas_func(), 0);
+        GL.IssuePluginEvent(PFPluginExports.get_shutdown_func(), 0);
     }
 }

--- a/unity-project/Assets/Pathfinder/PFPlugin.cs
+++ b/unity-project/Assets/Pathfinder/PFPlugin.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+public class PFPlugin {
+    public static void ReleaseResources() {
+        GL.IssuePluginEvent(PFPluginExports.get_render_canvas_func(), 0);
+    }
+}

--- a/unity-project/Assets/Pathfinder/PFPlugin.cs.meta
+++ b/unity-project/Assets/Pathfinder/PFPlugin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ceb8c4bedcb5662419a9ab285ac67597
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-project/Assets/Pathfinder/PFPluginExports.cs
+++ b/unity-project/Assets/Pathfinder/PFPluginExports.cs
@@ -6,5 +6,8 @@ internal class PFPluginExports {
     internal static extern IntPtr get_render_canvas_func();
 
     [DllImport("GfxPluginPathfinder")]
+    internal static extern IntPtr get_shutdown_func();
+
+    [DllImport("GfxPluginPathfinder")]
     internal static extern void queue_canvas_for_rendering(IntPtr handle, Int32 id);
 }

--- a/unity-project/Assets/PathfinderCameraScript.cs
+++ b/unity-project/Assets/PathfinderCameraScript.cs
@@ -43,7 +43,7 @@ public class PathfinderCameraScript : MonoBehaviour
             new Vector2(10.0f, 40.0f)
         );
 
-        canvas.QueueForRendering(1);
+        canvas.QueueForRendering();
 
         // This is temporary code just to make sure calls don't crash.
         path.Clone();

--- a/unity-project/Assets/PathfinderCameraScript.cs
+++ b/unity-project/Assets/PathfinderCameraScript.cs
@@ -1,20 +1,21 @@
 ﻿using UnityEngine;
-using System;
-using System.Runtime.InteropServices;
 
 public class PathfinderCameraScript : MonoBehaviour
 {
-    private PFCanvasFontContext fontContext;
+    public GameObject globalState;
+    private GlobalState gState;
 
     // Start is called before the first frame update
     void Start()
     {
-        fontContext = new PFCanvasFontContext();
+        gState = globalState.GetComponent<GlobalState>();
     }
 
     public void OnPostRender() {
+        if (!gState.IsPathfinderEnabled()) return;
+
         // Make a canvas. We're going to draw a house.
-        var canvas = new PFCanvas(fontContext, new Vector2(Screen.width, Screen.height));
+        var canvas = new PFCanvas(gState.GetFontContext(), new Vector2(Screen.width, Screen.height));
 
         canvas.SetStrokeStyle(Color.blue);
         canvas.SetFillStyle(Color.green);
@@ -37,19 +38,14 @@ public class PathfinderCameraScript : MonoBehaviour
 
         canvas.SetFillStyle(Color.black);
         canvas.SetFontSize(24.0f);
-        canvas.FillText("Hello world\u2026", new Vector2(10.0f, 40.0f));
+        canvas.FillText(
+            "Press “" + GlobalState.pathfinderToggleKey + "” to toggle Pathfinder.",
+            new Vector2(10.0f, 40.0f)
+        );
 
         canvas.QueueForRendering(1);
 
         // This is temporary code just to make sure calls don't crash.
         path.Clone();
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        if (Input.GetKey("escape")) {
-            Application.Quit();
-        }
     }
 }

--- a/unity-project/Assets/RenderTexture.renderTexture
+++ b/unity-project/Assets/RenderTexture.renderTexture
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!84 &8400000
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: RenderTexture
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  serializedVersion: 3
+  m_Width: 256
+  m_Height: 256
+  m_AntiAliasing: 1
+  m_DepthFormat: 2
+  m_ColorFormat: 8
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 0
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1

--- a/unity-project/Assets/RenderTexture.renderTexture.meta
+++ b/unity-project/Assets/RenderTexture.renderTexture.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6af86c66c0f241a47b67f7bb223752d0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 8400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-project/Assets/RenderTextureCameraScript.cs
+++ b/unity-project/Assets/RenderTextureCameraScript.cs
@@ -3,20 +3,38 @@
 public class RenderTextureCameraScript : MonoBehaviour
 {
     private PFCanvasFontContext fontContext;
+    public float fontSize;
+    private float fontVelocity;
+    private float maxFontSize;
+    private float minFontSize;
 
     // Start is called before the first frame update
     void Start()
     {
         fontContext = new PFCanvasFontContext();
+        fontSize = 10.0f;
+        fontVelocity = 1.0f;
+        maxFontSize = 160.0f;
+        minFontSize = 10.0f;
     }
 
     public void OnPostRender() {
         var canvas = new PFCanvas(fontContext, new Vector2(256, 256));
 
-        canvas.SetStrokeStyle(Color.red);
-        canvas.SetFontSize(128.0f);
-        canvas.FillText("Yo!", new Vector2(10.0f, 128.0f));
+        canvas.SetFontSize(fontSize);
+        canvas.FillText("Yo!", new Vector2(10.0f, fontSize));
 
         canvas.QueueForRendering(2);
+    }
+
+    public void Update() {
+        fontSize += fontVelocity;
+        if (fontSize > maxFontSize) {
+            fontSize = maxFontSize;
+            fontVelocity = -Mathf.Abs(fontVelocity);
+        } else if (fontSize < minFontSize) {
+            fontSize = minFontSize;
+            fontVelocity = Mathf.Abs(fontVelocity);
+        }
     }
 }

--- a/unity-project/Assets/RenderTextureCameraScript.cs
+++ b/unity-project/Assets/RenderTextureCameraScript.cs
@@ -14,8 +14,8 @@ public class RenderTextureCameraScript : MonoBehaviour
         var canvas = new PFCanvas(fontContext, new Vector2(256, 256));
 
         canvas.SetStrokeStyle(Color.red);
-        canvas.SetFontSize(12.0f);
-        canvas.FillText("Yo!", new Vector2(10.0f, 20.0f));
+        canvas.SetFontSize(128.0f);
+        canvas.FillText("Yo!", new Vector2(10.0f, 128.0f));
 
         canvas.QueueForRendering(2);
     }

--- a/unity-project/Assets/RenderTextureCameraScript.cs
+++ b/unity-project/Assets/RenderTextureCameraScript.cs
@@ -4,7 +4,7 @@ public class RenderTextureCameraScript : MonoBehaviour
 {
     public GameObject globalState;
     private GlobalState gState;
-    private Camera camera;
+    private Camera ourCamera;
     public float fontSize;
     private float fontVelocity;
     private float maxFontSize;
@@ -14,7 +14,7 @@ public class RenderTextureCameraScript : MonoBehaviour
     void Start()
     {
         gState = globalState.GetComponent<GlobalState>();
-        camera = GetComponent<Camera>();
+        ourCamera = GetComponent<Camera>();
         fontSize = 10.0f;
         fontVelocity = 1.0f;
         maxFontSize = 160.0f;
@@ -26,7 +26,7 @@ public class RenderTextureCameraScript : MonoBehaviour
             return;
         }
 
-        var tex = camera.targetTexture;
+        var tex = ourCamera.targetTexture;
         var size = new Vector2(tex.width, tex.height);
         var canvas = new PFCanvas(gState.GetFontContext(), size);
 

--- a/unity-project/Assets/RenderTextureCameraScript.cs
+++ b/unity-project/Assets/RenderTextureCameraScript.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+
+public class RenderTextureCameraScript : MonoBehaviour
+{
+    private PFCanvasFontContext fontContext;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        fontContext = new PFCanvasFontContext();
+    }
+
+    public void OnPostRender() {
+        var canvas = new PFCanvas(fontContext, new Vector2(256, 256));
+
+        canvas.SetStrokeStyle(Color.red);
+        canvas.SetFontSize(12.0f);
+        canvas.FillText("Yo!", new Vector2(10.0f, 20.0f));
+
+        canvas.QueueForRendering(2);
+    }
+}

--- a/unity-project/Assets/RenderTextureCameraScript.cs
+++ b/unity-project/Assets/RenderTextureCameraScript.cs
@@ -33,7 +33,7 @@ public class RenderTextureCameraScript : MonoBehaviour
         canvas.SetFontSize(fontSize);
         canvas.FillText("Yo!", new Vector2(10.0f, fontSize));
 
-        canvas.QueueForRendering(2);
+        canvas.QueueForRendering();
     }
 
     public void Update() {

--- a/unity-project/Assets/RenderTextureCameraScript.cs
+++ b/unity-project/Assets/RenderTextureCameraScript.cs
@@ -2,7 +2,8 @@
 
 public class RenderTextureCameraScript : MonoBehaviour
 {
-    private PFCanvasFontContext fontContext;
+    public GameObject globalState;
+    private GlobalState gState;
     public float fontSize;
     private float fontVelocity;
     private float maxFontSize;
@@ -11,7 +12,7 @@ public class RenderTextureCameraScript : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        fontContext = new PFCanvasFontContext();
+        gState = globalState.GetComponent<GlobalState>();
         fontSize = 10.0f;
         fontVelocity = 1.0f;
         maxFontSize = 160.0f;
@@ -19,7 +20,11 @@ public class RenderTextureCameraScript : MonoBehaviour
     }
 
     public void OnPostRender() {
-        var canvas = new PFCanvas(fontContext, new Vector2(256, 256));
+        if (!gState.IsPathfinderEnabled()) {
+            return;
+        }
+
+        var canvas = new PFCanvas(gState.GetFontContext(), new Vector2(256, 256));
 
         canvas.SetFontSize(fontSize);
         canvas.FillText("Yo!", new Vector2(10.0f, fontSize));

--- a/unity-project/Assets/RenderTextureCameraScript.cs
+++ b/unity-project/Assets/RenderTextureCameraScript.cs
@@ -4,6 +4,7 @@ public class RenderTextureCameraScript : MonoBehaviour
 {
     public GameObject globalState;
     private GlobalState gState;
+    private Camera camera;
     public float fontSize;
     private float fontVelocity;
     private float maxFontSize;
@@ -13,6 +14,7 @@ public class RenderTextureCameraScript : MonoBehaviour
     void Start()
     {
         gState = globalState.GetComponent<GlobalState>();
+        camera = GetComponent<Camera>();
         fontSize = 10.0f;
         fontVelocity = 1.0f;
         maxFontSize = 160.0f;
@@ -24,7 +26,9 @@ public class RenderTextureCameraScript : MonoBehaviour
             return;
         }
 
-        var canvas = new PFCanvas(gState.GetFontContext(), new Vector2(256, 256));
+        var tex = camera.targetTexture;
+        var size = new Vector2(tex.width, tex.height);
+        var canvas = new PFCanvas(gState.GetFontContext(), size);
 
         canvas.SetFontSize(fontSize);
         canvas.FillText("Yo!", new Vector2(10.0f, fontSize));

--- a/unity-project/Assets/RenderTextureCameraScript.cs.meta
+++ b/unity-project/Assets/RenderTextureCameraScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ac01ccf2619e284bac6cdfe192fcb96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-project/Assets/RenderTextureMaterial.mat
+++ b/unity-project/Assets/RenderTextureMaterial.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: RenderTextureMaterial
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 8400000, guid: 6af86c66c0f241a47b67f7bb223752d0, type: 2}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/unity-project/Assets/RenderTextureMaterial.mat.meta
+++ b/unity-project/Assets/RenderTextureMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c47cd80a86ac80145b46cbd541b86c64
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-project/Assets/RotateCube.cs
+++ b/unity-project/Assets/RotateCube.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RotateCube : MonoBehaviour
+{
+    private float angle = 0.0f;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        var transform = GetComponent<Transform>();
+        angle += 1.0f;
+        transform.rotation = Quaternion.AngleAxis(angle, new Vector3(0, 1, 1));        
+    }
+}

--- a/unity-project/Assets/RotateCube.cs.meta
+++ b/unity-project/Assets/RotateCube.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd8cce43f8b82c24ca033843e29bed70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-project/Assets/Scenes/SampleScene.unity
+++ b/unity-project/Assets/Scenes/SampleScene.unity
@@ -120,6 +120,102 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &670998793
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 670998797}
+  - component: {fileID: 670998796}
+  - component: {fileID: 670998795}
+  - component: {fileID: 670998794}
+  m_Layer: 0
+  m_Name: RenderTextureCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &670998794
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 670998793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ac01ccf2619e284bac6cdfe192fcb96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!81 &670998795
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 670998793}
+  m_Enabled: 0
+--- !u!20 &670998796
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 670998793}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 0
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 8400000, guid: 6af86c66c0f241a47b67f7bb223752d0, type: 2}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &670998797
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 670998793}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-project/Assets/Scenes/SampleScene.unity
+++ b/unity-project/Assets/Scenes/SampleScene.unity
@@ -416,3 +416,107 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3e5d5e6f7a7ea6047be17d99a524e0e5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &972286786
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 972286790}
+  - component: {fileID: 972286789}
+  - component: {fileID: 972286788}
+  - component: {fileID: 972286787}
+  - component: {fileID: 972286791}
+  m_Layer: 0
+  m_Name: RenderTextureCube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &972286787
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972286786}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &972286788
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972286786}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c47cd80a86ac80145b46cbd541b86c64, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &972286789
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972286786}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &972286790
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972286786}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.9, z: -5.65}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &972286791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972286786}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd8cce43f8b82c24ca033843e29bed70, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/unity-project/Assets/Scenes/SampleScene.unity
+++ b/unity-project/Assets/Scenes/SampleScene.unity
@@ -120,6 +120,49 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &80285846
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 80285848}
+  - component: {fileID: 80285847}
+  m_Layer: 0
+  m_Name: GlobalState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &80285847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80285846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0fa03d726a130845a85815341ba02ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &80285848
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 80285846}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &670998793
 GameObject:
   m_ObjectHideFlags: 0
@@ -151,6 +194,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ac01ccf2619e284bac6cdfe192fcb96, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  globalState: {fileID: 80285846}
+  fontSize: 0
 --- !u!81 &670998795
 AudioListener:
   m_ObjectHideFlags: 0
@@ -404,6 +449,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d8e66913b051e8b49af1204abd662521, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  globalState: {fileID: 80285846}
 --- !u!114 &963194230
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This adds some support for using Unity [Render Textures](https://docs.unity3d.com/Manual/class-RenderTexture.html) with Pathfinder.

The tricky part about this is that Unity appears to switch between 3-5 different GL Contexts (in a single thread) while render textures are in use.  This makes Pathfinder panic if we don't deal with it, because some objects, like vertex arrays and framebuffers, aren't shared between contexts, so OpenGL will set error conditions when Pathfinder tries binding something that doesn't exist on the currently active context.

My current solution is to maintain a separate renderer instance per context.  This feels kind of heavy and potentially could result in memory leaks if Unity actually releases any of its contexts (Unity doesn't _seem_ to provide any way of telling us when it's done using a context).

Unity's documentation for its [Low-level native plug-in interface](https://docs.unity3d.com/Manual/NativePluginInterface.html) does mention that it uses multiple contexts:

> Unity uses multiple OpenGL contexts. When initializing and closing the editor and the player, we rely on a master context but we use dedicated contexts for rendering.

However, I didn't realize that it used multiple different contexts outside of just initializing/shutting down its editor/player.
