### PR TITLE
Make a rust-based installer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ winapi = { version = "0.3", features = ["wingdi", "libloaderapi"] }
 # because it won't see the GL functions we've loaded in our version.
 gl = "0.6"
 
+# This is only needed by our installer script.
+fs_extra = "1.1"
+
 [dependencies.pathfinder_geometry]
 path = "pathfinder/geometry"
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,18 @@ The project currently only works on Windows, and it only supports
 Unity projects that use the OpenGL backend. It has been tested
 with Unity 2019.1.
 
+First, initialize the repository's git submodules:
+
 ```
 git submodule init
 git submodule update
-build_plugin
+```
+
+Then build the plugin and install it into the sample Unity
+project:
+
+```
+cargo run
 ```
 
 You will need to open the Unity project in the `unity-project` folder;
@@ -36,7 +44,7 @@ do the following:
    and attach a debugger to it.
 3. Make sure you are targeting `x64` in Visual Studio and press <kbd>F5</kbd>.
 
-Note that pressing <kbd>F5</kbd> automatically re-runs `build_plugin`, so you
+Note that pressing <kbd>F5</kbd> automatically re-runs `cargo run`, so you
 don't need to worry about re-running it manually.
 
 Logging produced by the plugin will be available in `dist/pathfinder-plugin.log`.

--- a/build_plugin.bat
+++ b/build_plugin.bat
@@ -1,9 +1,0 @@
-@echo off
-
-mkdir dist\unity-project_Data\Plugins 2>nul
-
-cargo build && ^
-copy target\debug\pathfinder_c_api_fun.dll unity-project\Assets\GfxPluginPathfinder.dll && ^
-copy target\debug\pathfinder_c_api_fun.dll dist\unity-project_Data\Plugins\GfxPluginPathfinder.dll && ^
-xcopy /q /s /y pathfinder\resources unity-project\Assets\StreamingAssets\pathfinder\ && ^
-xcopy /q /s /y pathfinder\resources dist\unity-project_Data\StreamingAssets\pathfinder\

--- a/dist/VSDebugHarness/VSDebugHarness/VSDebugHarness.vcxproj
+++ b/dist/VSDebugHarness/VSDebugHarness/VSDebugHarness.vcxproj
@@ -105,7 +105,7 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <CustomBuildStep>
-      <Command>cd $(ProjectDir)..\..\.. &amp;&amp; build_plugin.bat</Command>
+      <Command>cd $(ProjectDir)..\..\.. &amp;&amp; cargo run</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Building Unity Rust plugin</Message>

--- a/src/bin/installer.rs
+++ b/src/bin/installer.rs
@@ -5,6 +5,9 @@ use fs_extra::{dir, file};
 
 type PathParts = [&'static str];
 
+const RESOURCES_DIR: [&'static str; 2] = ["pathfinder", "resources"];
+const DLL_PATH: [&'static str; 3] = ["target", "debug", "pathfinder_c_api_fun.dll"];
+
 fn path_from_cwd(parts: &PathParts) -> PathBuf {
     let mut pathbuf = env::current_dir().unwrap();
     for part in parts.iter() {
@@ -14,7 +17,6 @@ fn path_from_cwd(parts: &PathParts) -> PathBuf {
 }
 
 fn copy_resources_dir(dest_dir: &PathParts) {
-    let resources_dir = ["pathfinder", "resources"];
     let copy_options = dir::CopyOptions {
         overwrite: true,
         skip_exist: false,
@@ -25,13 +27,12 @@ fn copy_resources_dir(dest_dir: &PathParts) {
     let dest_pathbuf = path_from_cwd(dest_dir);
     let erase = false;
 
-    println!("{} -> {}", resources_dir.join("/"), dest_dir.join("/"));
+    println!("{} -> {}", RESOURCES_DIR.join("/"), dest_dir.join("/"));
     dir::create_all(dest_pathbuf.clone(), erase).unwrap();
-    dir::copy(path_from_cwd(&resources_dir), dest_pathbuf, &copy_options).unwrap();
+    dir::copy(path_from_cwd(&RESOURCES_DIR), dest_pathbuf, &copy_options).unwrap();
 }
 
 fn copy_dll(dest_dir: &PathParts) {
-    let src = ["target", "debug", "pathfinder_c_api_fun.dll"];
     let mut dest = Vec::from(dest_dir);
     dest.push("GfxPluginPathfinder.dll");
     let options = file::CopyOptions {
@@ -40,7 +41,9 @@ fn copy_dll(dest_dir: &PathParts) {
         skip_exist: false,
     };
 
-    file::copy(path_from_cwd(&src), path_from_cwd(&dest), &options).unwrap();
+    println!("{} -> {}", DLL_PATH.join("/"), dest.join("/"));
+    dir::create_all(path_from_cwd(dest_dir), false).unwrap();
+    file::copy(path_from_cwd(&DLL_PATH), path_from_cwd(&dest), &options).unwrap();
 }
 
 fn build() {

--- a/src/bin/installer.rs
+++ b/src/bin/installer.rs
@@ -1,0 +1,35 @@
+use std::env;
+use std::path::PathBuf;
+use fs_extra::dir;
+
+type PathParts = [&'static str];
+
+fn path_from_cwd(parts: &PathParts) -> PathBuf {
+    let mut pathbuf = env::current_dir().unwrap();
+    for part in parts.iter() {
+        pathbuf.push(part);
+    }
+    pathbuf
+}
+
+fn copy_resources_dir(dest_dir: &PathParts) {
+    let resources_dir = ["pathfinder", "resources"];
+    let copy_options = dir::CopyOptions {
+        overwrite: true,
+        skip_exist: false,
+        buffer_size: 64000,
+        copy_inside: true,
+        depth: 0
+    };
+    let dest_pathbuf = path_from_cwd(dest_dir);
+    let erase = false;
+
+    println!("{} -> {}", resources_dir.join("/"), dest_dir.join("/"));
+    dir::create_all(dest_pathbuf.clone(), erase).unwrap();
+    dir::copy(path_from_cwd(&resources_dir), dest_pathbuf, &copy_options).unwrap();
+}
+
+fn main() {
+    copy_resources_dir(&["unity-project", "Assets", "StreamingAssets", "pathfinder"]);
+    copy_resources_dir(&["dist", "unity-project_Data", "StreamingAssets", "pathfinder"]);
+}

--- a/src/bin/installer.rs
+++ b/src/bin/installer.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::PathBuf;
+use std::process::Command;
 use fs_extra::dir;
 
 type PathParts = [&'static str];
@@ -29,7 +30,22 @@ fn copy_resources_dir(dest_dir: &PathParts) {
     dir::copy(path_from_cwd(&resources_dir), dest_pathbuf, &copy_options).unwrap();
 }
 
+fn build() {
+    let mut child = Command::new("cargo")
+        .arg("build")
+        .arg("--lib")
+        .spawn()
+        .expect("failed to run cargo");
+    let ecode = child.wait().expect("failed to wait on cargo");
+    if !ecode.success() {
+        std::process::exit(1);
+    }
+}
+
 fn main() {
+    println!("Building Pathfinder Unity plugin...");
+    build();
+    println!("Copying resource directories...");
     copy_resources_dir(&["unity-project", "Assets", "StreamingAssets", "pathfinder"]);
     copy_resources_dir(&["dist", "unity-project_Data", "StreamingAssets", "pathfinder"]);
 }


### PR DESCRIPTION
I'd like to replace the `build_plugin.bat` file with a rust-based binary that builds and installs everything.  That way one can run `cargo run` or `cargo run --release` to build and install everything in one fell swoop.

## To do

- [x] Make installer call `cargo build --lib`.
- [x] If run with `cfg(release)`, ensure that `--release` is passed to `cargo` and make sure the built DLL is copied from `release` rather than `debug`.
- [x] Copy built DLL to unity project and dist dir.
- [x] Make VS debug harness run `cargo run` instead of `build_plugin.bat`.
- [x] Remove `build_plugin.bat`.
- [x] Update README.
