### PR TITLE
Use canvas transform, save/restore

### DIFF
--- a/src/pathfinder_unity_api.rs
+++ b/src/pathfinder_unity_api.rs
@@ -313,6 +313,26 @@ pub unsafe extern "stdcall" fn PFCanvasSetLineDash(canvas: PFCanvasRef,
 }
 
 #[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasSetCurrentTransform(canvas: PFCanvasRef, transform: *const PFTransform2F) {
+    (*canvas).set_current_transform(&(*transform).to_rust());
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasResetTransform(canvas: PFCanvasRef) {
+    (*canvas).reset_transform();
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasSave(canvas: PFCanvasRef) {
+    (*canvas).save();
+}
+
+#[no_mangle]
+pub unsafe extern "stdcall" fn PFCanvasRestore(canvas: PFCanvasRef) {
+    (*canvas).restore();
+}
+
+#[no_mangle]
 pub unsafe extern "stdcall" fn PFCanvasSetLineDashOffset(canvas: PFCanvasRef, new_offset: f32) {
     (*canvas).set_line_dash_offset(new_offset)
 }

--- a/unity-project/Assets/MainCameraOverlayScript.cs
+++ b/unity-project/Assets/MainCameraOverlayScript.cs
@@ -1,30 +1,5 @@
 ﻿using UnityEngine;
 
-/// <summary>
-/// This is a poor substitute for HTML Canvas' transformation API,
-/// which we don't currently support. We should eventually support
-/// it and then get rid of this stopgap.
-/// </summary>
-class GeomMaker {
-    public float scale;
-    public Vector2 translate;
-
-    public GeomMaker(float scale, Vector2 translate) {
-        this.scale = scale;
-        this.translate = translate;
-    }
-
-    public Rect MakeRect(float x, float y, float width, float height) {
-        return new Rect(
-            new Vector2(x, y) * scale + translate,
-            new Vector2(width, height) * scale
-        );
-    }
-
-    public Vector2 MakeVector2(float x, float y) {
-        return new Vector2(x, y) * scale + translate;
-    }
-}
 
 public class MainCameraOverlayScript : MonoBehaviour
 {
@@ -39,25 +14,35 @@ public class MainCameraOverlayScript : MonoBehaviour
         instructions = new PFString("Press “" + InputScript.pathfinderToggleKey + "” to toggle Pathfinder.");
     }
 
-    private void DrawHouse(PFCanvas canvas, GeomMaker geom) {
+    private void DrawHouse(PFCanvas canvas) {
+        var scale = 0.5f;
+
+        canvas.Save();
+
+        canvas.SetCurrentTransform(
+            Matrix4x4.Translate(new Vector2(0, Screen.height - 160)) *
+            Matrix4x4.Scale(new Vector2(scale, scale))
+        );
+        canvas.SetLineWidth(10.0f * scale);
         canvas.SetStrokeStyle(Color.black);
         canvas.SetFillStyle(Color.black);
         canvas.SetLineJoin(PFLineJoin.Round);
-        canvas.SetLineWidth(10.0f * geom.scale);
 
         // Draw walls.
-        canvas.StrokeRect(geom.MakeRect(75.0f, 140.0f, 150.0f, 110.0f));
+        canvas.StrokeRect(new Rect(75.0f, 140.0f, 150.0f, 110.0f));
 
         // Draw door.
-        canvas.FillRect(geom.MakeRect(130.0f, 190.0f, 40.0f, 60.0f));
+        canvas.FillRect(new Rect(130.0f, 190.0f, 40.0f, 60.0f));
 
         // Draw roof.
         var path = new PFPath();
-        path.MoveTo(geom.MakeVector2(50.0f, 140.0f));
-        path.LineTo(geom.MakeVector2(150.0f, 60.0f));
-        path.LineTo(geom.MakeVector2(250.0f, 140.0f));
+        path.MoveTo(new Vector2(50.0f, 140.0f));
+        path.LineTo(new Vector2(150.0f, 60.0f));
+        path.LineTo(new Vector2(250.0f, 140.0f));
         path.ClosePath();
         canvas.StrokePath(path);
+
+        canvas.Restore();
     }
 
     private void DrawInstructions(PFCanvas canvas) {
@@ -75,7 +60,7 @@ public class MainCameraOverlayScript : MonoBehaviour
 
         var canvas = new PFCanvas(gState.GetFontContext(), new Vector2(Screen.width, Screen.height));
 
-        DrawHouse(canvas, new GeomMaker(0.5f, new Vector2(0, Screen.height - 160)));
+        DrawHouse(canvas);
         DrawInstructions(canvas);
 
         canvas.QueueForRendering();

--- a/unity-project/Assets/Pathfinder/PF.cs
+++ b/unity-project/Assets/Pathfinder/PF.cs
@@ -248,6 +248,18 @@ internal class PF {
     internal static extern void PFCanvasSetLineDash(IntPtr /* CanvasRenderingContext2D */ canvas, IntPtr /* float */ new_line_dashes, UIntPtr new_line_dash_count);
 
     [DllImport("GfxPluginPathfinder")]
+    internal static extern void PFCanvasSetCurrentTransform(IntPtr /* CanvasRenderingContext2D */ canvas, ref PFTransform2F transform);
+
+    [DllImport("GfxPluginPathfinder")]
+    internal static extern void PFCanvasResetTransform(IntPtr /* CanvasRenderingContext2D */ canvas);
+
+    [DllImport("GfxPluginPathfinder")]
+    internal static extern void PFCanvasSave(IntPtr /* CanvasRenderingContext2D */ canvas);
+
+    [DllImport("GfxPluginPathfinder")]
+    internal static extern void PFCanvasRestore(IntPtr /* CanvasRenderingContext2D */ canvas);
+
+    [DllImport("GfxPluginPathfinder")]
     internal static extern void PFCanvasSetLineDashOffset(IntPtr /* CanvasRenderingContext2D */ canvas, float new_offset);
 
     [DllImport("GfxPluginPathfinder")]

--- a/unity-project/Assets/Pathfinder/PFCanvas.cs
+++ b/unity-project/Assets/Pathfinder/PFCanvas.cs
@@ -73,6 +73,34 @@ public class PFCanvas {
         PF.PFCanvasSetFontSize(handle, size);
     }
 
+    public void Save() {
+        EnsureHandleIsValid();
+        PF.PFCanvasSave(handle);
+    }
+
+    public void Restore() {
+        EnsureHandleIsValid();
+        PF.PFCanvasRestore(handle);
+    }
+
+    public void SetCurrentTransform(Matrix4x4 matrix) {
+        EnsureHandleIsValid();
+        var pfMatrix = new PFMatrix2x2F(
+            matrix.m00,
+            matrix.m01,
+            matrix.m10,
+            matrix.m11
+        );
+        var pfVector = new PFVector2F(matrix.m03, matrix.m13);
+        var pfTransform = new PFTransform2F(pfMatrix, pfVector);
+        PF.PFCanvasSetCurrentTransform(handle, ref pfTransform);
+    }
+
+    public void ResetTransform() {
+        EnsureHandleIsValid();
+        PF.PFCanvasResetTransform(handle);
+    }
+
     public void FillRect(Rect rect) {
         EnsureHandleIsValid();
         var pfRect = PFUnityConv.PFRectF(rect);


### PR DESCRIPTION
This builds off the as-of-yet unmerged https://github.com/servo/pathfinder/pull/216 to get rid of our `GeomMaker` class and instead use the canvas' built-in transformation and save/restore functionality.

Once the PR is merged into Pathfinder, I will merge this PR.